### PR TITLE
Add a new route to be able to count the docs without fetching the list

### DIFF
--- a/app/controllers/ModelsController.js
+++ b/app/controllers/ModelsController.js
@@ -55,6 +55,18 @@ const makeModelsController = (db, config, emitter) => {
     });
   });
 
+  ModelsController.getAsync('/count', async (req, res) => {
+    const mongo = queryToMongo(req.query, {
+      maxLimit: config.maxLimit,
+    });
+
+    const total = await db.countDocuments(mongo.criteria, mongo.options);
+
+    res.json({
+      total,
+    });
+  });
+
   ModelsController.getAsync('/:id', async (req, res) => {
     const { id } = req.params;
     const doc = await db.findOne({ _id: id });

--- a/test/controllers/models-controller.test.js
+++ b/test/controllers/models-controller.test.js
@@ -108,3 +108,10 @@ test('it cannot delete with an invalid signature', async () => {
   const dbModel = await radiksData.findOne({ _id: model._id });
   expect(dbModel).not.toBeNull();
 });
+
+test('it can count', async () => {
+  const app = await getApp();
+  await saveAll();
+  const response = await request(app).get('/radiks/models/count').query({});
+  expect(response.body.total).toBe(7);
+});


### PR DESCRIPTION
The client have a `Model.count()` method that return a number see associated pr https://github.com/blockstack-radiks/radiks/pull/32